### PR TITLE
add ability to write exercise name with spaces

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,10 +24,15 @@ export function activate(context: vscode.ExtensionContext) {
 		const exercismApp = await env.run(getExercismAppPath);
 
 		if (exercismApp && await env.run(ensureToken, exercismApp)) {
-			const exerciseName = await showInputBox({
-				placeHolder: 'Track/Exercise name'
+			const track = await showInputBox({
+				placeHolder: 'Track name'
 			});
-			const [track, name] = exerciseName.split('/');
+			const name = (await showInputBox({
+				placeHolder: 'Exercise name'
+			}))
+			.toLowerCase()
+			.replace(' ', '-');
+			
 			vscode.window.withProgress({
 				location: vscode.ProgressLocation.Notification,
 				title: `Downloading exercise ${name}`


### PR DESCRIPTION
- when I tried to fetch exercise `go/Two fer` it didn't work because I should write the extension name as it is supplied to the command so I wanted to ease the process of fetching the exercise so the user can write the exercise name as it appears on exercism. 
- I also found that asking the track name then the exercise name would be easier than writing them slash-separated.

Thank you :smile: 
BTW, I like the extension. :heart: 