### PR TITLE
trim whitespaces from exercise name

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,6 +49,7 @@ export function activate(context: vscode.ExtensionContext) {
 				placeHolder: 'Exercise name'
 			}))
 			.toLowerCase()
+			.trim()
 			.replace(' ', '-');
 			
 			vscode.window.withProgress({


### PR DESCRIPTION
this fixes the issue when a user might add a space at the end(or the beginning) of the exercise name, for example, the exercise named `leap `.  (mistakenly adding a space at the end) would lead to downloading the exercise named as "leap-" so we should trim the white spaces before replacing them with `-` dashes