### PR TITLE
Fixed minor errors

### DIFF
--- a/src/exercism.ts
+++ b/src/exercism.ts
@@ -24,7 +24,7 @@ export const getExercismAppPath = async (conf: IEnviroment) => {
     const exercismApp = conf.get<string>('app.path');
     if (!exercismApp) {
         // search in current path
-        const defaultAppName = isWindows
+        const defaultAppName = isWindows()
             ? 'exercism.exe'
             : 'exercism';
         const defaultAppPath = await programExistsInPath(defaultAppName);

--- a/src/exercism.ts
+++ b/src/exercism.ts
@@ -65,7 +65,7 @@ export const getExercismConfigPath = async (env: IEnviroment, apppath: string) =
 		return dir;
 	}
 	catch (e) {
-		env.showError(e);
+		env.showError(String(e));
 		return undefined;
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -120,15 +120,9 @@ export function activate(context: vscode.ExtensionContext) {
 		}
 	});
 
-	vscode.workspace.onDidChangeWorkspaceFolders(_ => {
-		updateContext();
-	});
-	vscode.workspace.onDidChangeConfiguration(_ => {
-		updateContext();
-	});
-	vscode.workspace.onDidOpenTextDocument(_ => {
-		updateContext();
-	});
+	vscode.workspace.onDidChangeWorkspaceFolders(updateContext);
+	vscode.workspace.onDidChangeConfiguration(updateContext);
+	vscode.workspace.onDidOpenTextDocument(updateContext);
 
 	context.subscriptions.push(fetchCommand);
 	context.subscriptions.push(submitCommand);


### PR DESCRIPTION
 In `src/exercism.ts`:
1. On line 27, function `isWindows` was not actually called - this was probably an accident.
2. On line 68, casted error `e` to `String` explicitly to stop the type checker from complaining.